### PR TITLE
Adding optional parameter "bucket region name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ AWS_ACCESS_KEY_ID="your_key" \
 AWS_SECRET_ACCESS_KEY="your_secret" \
 letsencrypt --agree-tos -a letsencrypt-s3front:auth \
 --letsencrypt-s3front:auth-s3-bucket the_bucket \
+[ --letsencrypt-s3front:auth-s3-region your-bucket-region-name ] (default is us-west-1) \
 -i letsencrypt-s3front:installer \
 --letsencrypt-s3front:installer-cf-distribution-id your_cf_distribution_id \
 -d the_domain

--- a/letsencrypt_s3front/authenticator.py
+++ b/letsencrypt_s3front/authenticator.py
@@ -28,7 +28,7 @@ class Authenticator(common.Plugin):
     def add_parser_arguments(cls, add):
         add("s3-bucket", default=os.getenv('S3_BUCKET'),
             help="Bucket referenced by CloudFront distribution")
-        add("s3-region", default="us-west-1",
+        add("s3-region", default="us-east-1",
             help="Bucket region name")
 
     def __init__(self, *args, **kwargs):

--- a/letsencrypt_s3front/authenticator.py
+++ b/letsencrypt_s3front/authenticator.py
@@ -28,6 +28,8 @@ class Authenticator(common.Plugin):
     def add_parser_arguments(cls, add):
         add("s3-bucket", default=os.getenv('S3_BUCKET'),
             help="Bucket referenced by CloudFront distribution")
+        add("s3-region", default="us-west-1",
+            help="Bucket region name")
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)
@@ -53,7 +55,7 @@ class Authenticator(common.Plugin):
         # upload the challenge file to the desired s3 bucket
         # then run simple http verification
         response, validation = achall.response_and_validation()
-        s3 = boto3.resource('s3')
+        s3 = boto3.resource('s3', region_name=self.conf('s3-region'))
 
         s3.Bucket(self.conf('s3-bucket')).put_object(Key=achall.chall.path[1:],
                                                      Body=validation,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from distutils.core import setup
 from setuptools import find_packages
 
-version = '0.1.0'
+version = '0.1.1'
 
 install_requires = [
     'acme>={0}'.format(version),


### PR DESCRIPTION
To use s3 api on a bucket outside default region (us-west-1), region_name must be specifyed, in other case End Point must be used instead bucket name, which is not a great option in some cases.