### PR TITLE
Please check before merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Once you are done you should have a domain pointing to a CloudFront distribution
 that will use an S3 bucket for origin. It is important for the certificate
 validation that both HTTP and HTTPS traffic are enabled (at least while you get
   the certificate).
+  
+You can view an example IAM policy (sample-aws-policy.json) with the permissions needed for this plugin.
 
 ### Setup
 

--- a/letsencrypt_s3front/authenticator.py
+++ b/letsencrypt_s3front/authenticator.py
@@ -74,6 +74,7 @@ class Authenticator(common.Plugin):
         # pylint: disable=missing-docstring,no-self-use,unused-argument
         s3 = boto3.resource('s3', region_name=self.conf('s3-region'))
         client = s3.meta.client
-        for achall in achalls:
-            client.delete_object(Bucket=self.conf('s3-bucket'), Key=achall.chall.path[1:])
+        if achalls is not None:
+            for achall in achalls:
+                client.delete_object(Bucket=self.conf('s3-bucket'), Key=achall.chall.path[1:])
         return None

--- a/letsencrypt_s3front/installer.py
+++ b/letsencrypt_s3front/installer.py
@@ -66,7 +66,9 @@ class Installer(common.Plugin):
         cert_id = response['ServerCertificateMetadata']['ServerCertificateId']
         # Update CloudFront config to use the new one
         cf_cfg = cf_client.get_distribution_config(Id=self.conf('cf-distribution-id'))
-        cf_cfg['DistributionConfig']['ViewerCertificate']['IAMCertificateId'] = cert_id
+        cf_cfg['DistributionConfig']['ViewerCertificate']['IAMCertificateId'] = cert_id        
+        cf_cfg['DistributionConfig']['ViewerCertificate']['Certificate'] = cert_id
+        cf_cfg['DistributionConfig']['ViewerCertificate']['CertificateSource'] = "iam"
         try:
             cf_cfg['DistributionConfig']['ViewerCertificate'].pop('CloudFrontDefaultCertificate')
         except KeyError:
@@ -81,7 +83,7 @@ class Installer(common.Plugin):
                 ServerCertificateName=name
             )
         except botocore.exceptions.ClientError as e:
-            logger.error(e)
+            pass
 
         # Rename cert to the new one
         client.update_server_certificate(

--- a/letsencrypt_s3front/installer.py
+++ b/letsencrypt_s3front/installer.py
@@ -1,5 +1,6 @@
 """S3/CloudFront Let's Encrypt installer plugin."""
 import os
+import sys
 import logging
 import re
 import subprocess
@@ -47,7 +48,9 @@ class Installer(common.Plugin):
         """
         Upload Certificate to IAM and assign it to the CloudFront distribution
         """
-
+        if self.config.rsa_key_size > 2048:
+            print "The maximum public key size allowed for Cloudfront is 2048 (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html)\n Please, use --rsa_key_size 2048 or edit your cli.ini"
+            sys.exit(1)
         client = boto3.client('iam')
         cf_client = boto3.client('cloudfront')
 
@@ -55,7 +58,7 @@ class Installer(common.Plugin):
         body = open(cert_path).read()
         key = open(key_path).read()
         chain = open(chain_path).read()
-        # Uplaod cert to IAM
+        # Upload cert to IAM
         response = client.upload_server_certificate(
             Path="/cloudfront/letsencrypt/",
             ServerCertificateName=name + '-new',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from distutils.core import setup
 from setuptools import find_packages
 
-version = '0.1.1'
+version = '0.1.2'
 
 install_requires = [
     'acme>={0}'.format(version),


### PR DESCRIPTION
With these commits letsencrypt_s3front is working ok, but I'm getting an error:

(from /var/log/letsencrypt/letsencrypt.log)
```
2015-12-23 10:38:26,954:DEBUG:botocore.hooks:Event needs-retry.iam.UpdateServerCertificate: calling handler <botocore.retryhandler.RetryHandler object at 0xb4df5d30>
2015-12-23 10:38:26,958:DEBUG:botocore.retryhandler:No retry needed.
2015-12-23 10:38:26,961:DEBUG:botocore.hooks:Event after-call.iam.UpdateServerCertificate: calling handler <function json_decode_policies at 0xb51669f0>
2015-12-23 10:38:27,031:DEBUG:letsencrypt.cli:Exiting abnormally:
Traceback (most recent call last):
  File "/root/.local/share/letsencrypt/bin/letsencrypt", line 9, in <module>
    load_entry_point('letsencrypt==0.2.0.dev0', 'console_scripts', 'letsencrypt')()
  File "/root/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt-0.2.0.dev0-py2.7.egg/letsencrypt/cli.py", line 1398, in main
    return args.func(args, config, plugins)
  File "/root/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt-0.2.0.dev0-py2.7.egg/letsencrypt/cli.py", line 565, in run
    le_client.enhance_config(domains, config)
  File "/root/.local/share/letsencrypt/lib/python2.7/site-packages/letsencrypt-0.2.0.dev0-py2.7.egg/letsencrypt/client.py", line 411, in enhance_config
    redirect = config.redirect if "redirect" in supported else False
TypeError: argument of type 'NoneType' is not iterable
```

It doesn't breaks anything (the cert is installed correctly on Amazon), and I'm not sure if the error comes from the plugin or the letsencrypt version I'm using (0.2.0.dev0), but the error could confuse the end user.

Also, I'm including 2 domains on the same call (letsencrypt -d mydomain.com,www.mydomain.com ...) and using the option --reinstall instead renewing (I already depleted my 5 cert renews per 7 days to check further)


Could you test with a stable letsencrypt version and using only 1 domain?
